### PR TITLE
Fixed signed assembly output to include file version attributes

### DIFF
--- a/build/NMoneys.psm1
+++ b/build/NMoneys.psm1
@@ -142,11 +142,12 @@ function Sign-Assemblies($base, $configuration)
 {
 	$assembly = Join-Path $base \src\NMoneys\bin\$configuration\NMoneys.dll
 	$il_file = Join-Path $base \release\signed\NMoneys.il
+	$res_file = Join-Path $Base \release\signed\NMoneys.res
 	$signed_assembly = Join-Path $base \release\signed\NMoneys.dll
 	
 	ildasm $assembly /out:$il_file
 	Throw-If-Error "Could disassemble $assembly_file"
-	ilasm $il_file /dll /key=$base\NMoneys.key.snk /output=$signed_assembly /quiet
+	ilasm $il_file /dll /key=$base\NMoneys.key.snk /output=$signed_assembly /quiet /res=$res_file
 	Throw-If-Error "Could not assemble $il_file"
 }
 


### PR DESCRIPTION
Motivation
----------
Signed assembly loses resources with version information, etc.  This can
confuse some installers, such as Windows Installer.

Modifications
-------------
After disassembly, include resource file in compile of signed DLL.

Results
-------
Signed assembly now has version resource.